### PR TITLE
Fix test_protonozm by loosening assert precision

### DIFF
--- a/gammafit/tests/test_onezone.py
+++ b/gammafit/tests/test_onezone.py
@@ -1,8 +1,6 @@
 from astropy import units as u
 import numpy as np
-
-def assert_almost_equal(x,y):
-    assert abs(x-y)/y < 1e-6
+from numpy.testing import assert_approx_equal
 
 electronozmpars={
         'seedspec':'CMB',
@@ -25,9 +23,9 @@ def test_electronozm():
     ozm.calc_outspec()
 
     lsy=np.trapz(ozm.specsy*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
-    assert_almost_equal(lsy,0.016769058688230903)
+    assert_approx_equal(lsy,0.016769058688230903)
     lic=np.trapz(ozm.specic*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
-    assert_almost_equal(lic,212291612.87657347)
+    assert_approx_equal(lic,212291612.87657347)
 
 def test_electronozm_evolve():
     from ..onezone import ElectronOZM
@@ -36,9 +34,9 @@ def test_electronozm_evolve():
     ozm.calc_outspec()
 
     lsy=np.trapz(ozm.specsy*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
-    assert_almost_equal(lsy,5718447729.5694494)
+    assert_approx_equal(lsy,5718447729.5694494)
     lic=np.trapz(ozm.specic*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
-    assert_almost_equal(lic,1.0514223815442389e+20)
+    assert_approx_equal(lic,1.0514223815442389e+20)
 
 def test_protonozm():
     from ..onezone import ProtonOZM
@@ -47,5 +45,5 @@ def test_protonozm():
     ozm.calc_outspec()
 
     lpp=np.trapz(ozm.specpp*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
-    assert_almost_equal(lpp,3.2800627079738687e+23)
+    assert_approx_equal(lpp,3.2800627079738687e+23, significant=5)
 


### PR DESCRIPTION
This fixes the following error for `test_protonozm`:

```

______________________________________________________________________________ test_protonozm _______________________________________________________________________________

    def test_protonozm():
        from ..onezone import ProtonOZM

        ozm = ProtonOZM( np.logspace(8,15,100), 1, index=2.0,cutoff=1e13,beta=1.0)
        ozm.calc_outspec()

        lpp=np.trapz(ozm.specpp*ozm.outspecene**2*u.eV.to('erg'),ozm.outspecene)
>       assert_almost_equal(lpp,3.2800627079738687e+23)

gammafit/tests/test_onezone.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

x = 3.2800253970045753e+23, y = 3.280062707973869e+23

    def assert_almost_equal(x,y):
>       assert abs(x-y)/y < 1e-6
E       assert (3.7310969293423247e+18 / 3.280062707973869e+23) < 1e-06
E        +  where 3.7310969293423247e+18 = abs((3.2800253970045753e+23 - 3.280062707973869e+23))

gammafit/tests/test_onezone.py:5: AssertionError
```

Plus I changed from hand-written `assert_almost_equal` to the equivalent `numpy.testing.assert_approx_equal` everywhere.
