### PR TITLE
Some minor fixes

### DIFF
--- a/docs/fitting.rst
+++ b/docs/fitting.rst
@@ -5,4 +5,4 @@ Fitting a model to a spectrum
 Loading the data
 ----------------
 
-see `dataformat`.
+see :ref:`dataformat`.

--- a/gammafit/core.py
+++ b/gammafit/core.py
@@ -129,10 +129,10 @@ def get_sampler(data_table=None, p0=None, model=None, prior=None,
 
     Parameters
     ----------
-    data_table : :class:`~astropy.table.Table` instance
+    data_table : `~astropy.table.Table`
         Table containing the observed spectrum. The table needs at least these
         columns, with the appropriate associated units (with the physical type
-        indicated in brackets below) as either a :class:`~astropy.units.Unit`
+        indicated in brackets below) as either a `~astropy.units.Unit`
         instance or parseable string:
 
         - ``energy``: Observed photon energy [``energy``]
@@ -152,7 +152,7 @@ def get_sampler(data_table=None, p0=None, model=None, prior=None,
 
         The ``keywords`` metadata field of the table can be used to provide the
         confidence level of the upper limits with the keyword ``cl``, which
-        defaults to 90%. The :class:`astropy.io.ascii` reader can recover all
+        defaults to 90%. The `astropy.io.ascii` reader can recover all
         the needed information from ASCII tables in the
         :class:`~astropy.io.ascii.Ipac` and :class:`~astropy.io.ascii.Daophot`
         formats, and everything except the ``cl`` keyword from tables in the
@@ -184,7 +184,7 @@ def get_sampler(data_table=None, p0=None, model=None, prior=None,
         chain history discarded. It is necessary to settle the sampler into the
         maximum of the parameter space density. Default is 100.
     labels : iterable of strings, optional
-        Labels for the parameters included in the position vector `p0`. If not
+        Labels for the parameters included in the position vector ``p0``. If not
         provided ``['par1','par2', ... ,'parN']`` will be used.
     threads : int, optional
         Number of threads to use for sampling. Default is 4.
@@ -195,8 +195,8 @@ def get_sampler(data_table=None, p0=None, model=None, prior=None,
     Returns
     -------
     sampler : :class:`~emcee.EnsembleSampler` instance
-        Ensemble sampler with walker positions after `nburn` burn-in steps.
-    pos : :class:`~numpy.array`
+        Ensemble sampler with walker positions after ``nburn`` burn-in steps.
+    pos : :class:`~numpy.ndarray`
         Final position vector array.
 
     See also

--- a/gammafit/models.py
+++ b/gammafit/models.py
@@ -204,7 +204,7 @@ class LogParabola(object):
 
     See Also
     --------
-    PowerLaw, BrokenPowerLaw, EeponentialCutoffPowerLaw
+    PowerLaw, BrokenPowerLaw, ExponentialCutoffPowerLaw
 
     Notes
     -----

--- a/gammafit/plot.py
+++ b/gammafit/plot.py
@@ -362,7 +362,7 @@ def plot_fit(sampler, modelidx=0,xlabel=None,ylabel=None,confs=[3, 1, 0.5],
     """
     Plot data with fit confidence regions.
 
-    Additional ``kwargs`` are passed to `plotCI`.
+    Additional ``kwargs`` are passed to `plot_CI`.
 
     Parameters
     ----------
@@ -379,14 +379,14 @@ def plot_fit(sampler, modelidx=0,xlabel=None,ylabel=None,confs=[3, 1, 0.5],
     confs : list, optional
         List of confidence levels (in sigma) to use for generating the
         confidence intervals. Default is ``[3,1,0.5]``
-    figure : `matplotlib.figure`, optional
+    figure : `matplotlib.figure.Figure`, optional
         `matplotlib` figure to plot on. If omitted a new one will be generated.
     residualCI : bool, optional
         Whether to plot the confidence interval bands in the residuals subplot.
     plotdata : bool, optional
         Wheter to plot data on top of model confidence intervals. Default is
         True if the physical types of the data and the model match.
-    e_unit : :class:`~astropy.unit.Unit`
+    e_unit : `~astropy.units.Unit`
         Units for the energy axis of the plot. The default is to use the units
         of the energy array of the observed data.
 
@@ -596,7 +596,7 @@ def plot_data(sampler, xlabel=None,ylabel=None,
         Label for the ``y`` axis of the plot.
     sed : bool, optional
         Whether to plot SED or differential spectrum.
-    figure : `matplotlib.figure`, optional
+    figure : `matplotlib.figure.Figure`, optional
         `matplotlib` figure to plot on. If omitted a new one will be generated.
 
     """

--- a/gammafit/radiative.py
+++ b/gammafit/radiative.py
@@ -10,7 +10,7 @@ __all__ = ['Synchrotron', 'InverseCompton', 'PionDecay']
 from astropy.extern import six
 import logging
 # Get a new logger to avoid changing the level of the astropy logger
-log = logging.getLogger('gammafit.onezone')
+log = logging.getLogger('gammafit.radiative')
 
 # Constants and units
 from astropy import units as u
@@ -40,7 +40,7 @@ def _validate_ene(ene):
     return ene
 
 class Synchrotron(object):
-    """Synchrotron emission from an electron population
+    """Synchrotron emission from an electron population.
 
     Parameters
     ----------
@@ -49,7 +49,7 @@ class Synchrotron(object):
         TeV and returning the particle energy density in units of number of
         electrons per TeV.
 
-    B : :class:`~astropy.units.quantity.Quantity` float instance, optional
+    B : :class:`~astropy.units.Quantity` float instance, optional
         Isotropic magnetic field strength. Default: equipartition
         with CMB (3.24e-6 G)
     """
@@ -135,7 +135,7 @@ class Synchrotron(object):
         return (spec * outspecene ** 2.).to('erg/s')
 
 class InverseCompton(object):
-    """Synchrotron emission from an electron population
+    """Synchrotron emission from an electron population.
 
     Parameters
     ----------

--- a/gammafit/utils.py
+++ b/gammafit/utils.py
@@ -198,22 +198,22 @@ def build_data_table(ene, flux, flux_error=None, flux_error_lo=None,
 
     flux_error, flux_error_hi, flux_error_lo : :class:`~astropy.units.Quantity` array instance
         68% CL gaussian uncertainty of the flux [physical type ``flux`` or
-        ``differential flux``]. Either `flux_error` (symmetrical uncertainty) or
-        `flux_error_hi` and `flux_error_lo` (asymmetrical uncertainties) must be
+        ``differential flux``]. Either ``flux_error`` (symmetrical uncertainty) or
+        ``flux_error_hi`` and ``flux_error_lo`` (asymmetrical uncertainties) must be
         provided.
 
     ene_width, ene_lo, ene_hi : :class:`~astropy.units.Quantity` array instance, optional
-        Width of the energy bins [physical type ``energy``]. Either `ene_width`
-        (bin width) or `ene_lo` and `ene_hi` (Energies of the lower and upper
+        Width of the energy bins [physical type ``energy``]. Either ``ene_width``
+        (bin width) or ``ene_lo`` and ``ene_hi`` (Energies of the lower and upper
         bin edges) can be provided. If none are provided,
-        `generate_energy_edges` will be used.
+        ``generate_energy_edges`` will be used.
 
     ul : boolean or int array, optional
-        Boolean array indicating which of the flux values given in `flux`
+        Boolean array indicating which of the flux values given in ``flux``
         correspond to upper limits.
 
     cl : float, optional
-        Confidence level of the flux upper limits given by `ul`.
+        Confidence level of the flux upper limits given by ``ul``.
 
     Returns
     -------


### PR DESCRIPTION
Some minor docs fixes while I was browsing through the code ...

There's a few other things that could be improved, but I don't have the time to do it this week:
- There's no Sphinx search field when building the docs locally with `python setup.py build_sphinx`. Maybe adopt the Astropy docs template or fix this some other way?
- Astropy and the package template use `docs/api` as an output folder to store the auto-generated API docs. You put hand-written `rst` files there, which I first deleted by accident trying to produce a clean Sphinx build. Maybe change this?
