### PR TITLE
Build docs in a conda environment

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,22 +41,6 @@ except ImportError:
     # If that doesn't work trying to import from astropy_helpers below will
     # still blow up
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if on_rtd:
-    if sys.version_info.major > 2:
-        from unittest.mock import MagicMock
-    else:
-        from mock import Mock as MagicMock
-
-    class Mock(MagicMock):
-        @classmethod
-        def __getattr__(cls, name):
-                return Mock()
-
-    MOCK_MODULES = ['h5py',]
-    sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
-
 # Load all of the global Astropy configuration
 from astropy_helpers.sphinx.conf import *
 
@@ -201,4 +185,3 @@ if eval(setup_cfg.get('edit_on_github')):
 
     edit_on_github_source_root = ""
     edit_on_github_doc_root = "docs"
-

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,13 @@
+name: naima-docs
+channels:
+  - defaults
+  - astropy
+dependencies:
+  - python=3.6
+  - numpy
+  - matplotlib
+  - numpydoc
+  - scipy
+  - astropy
+  - emcee
+  - h5py

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+  file: docs/environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,5 @@
 conda:
   file: docs/environment.yml
+python:
+  version: 3
+  setup_py_install: true

--- a/setup.py
+++ b/setup.py
@@ -87,18 +87,12 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-# Some dependencies with C extensions cannot be built on readthedocs
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-if on_rtd:
-    install_requires = []
-else:
-    install_requires=['astropy>=1.0.2',
-                      'emcee>=2.2.0',
-                      'corner',
-                      'matplotlib',
-                      'scipy',
-                      'h5py'],
-
+install_requires = ['astropy>=1.0.2',
+                    'emcee>=2.2.0',
+                    'corner',
+                    'matplotlib',
+                    'scipy',
+                    'h5py'],
 
 setup(name=PACKAGENAME,
       version=VERSION,


### PR DESCRIPTION
This avoids having to mock out h5py in readthedocs.