### PR TITLE
Fix plotting test

### DIFF
--- a/naima/tests/test_plotting.py
+++ b/naima/tests/test_plotting.py
@@ -100,7 +100,7 @@ def test_plot_data_reuse_fig(sampler):
     # change the energy units between calls
     data = sampler.data
     fig = plot_data(data, sed=True)
-    data['energy'] = (data['energy']/1000).to('keV')
+    data['energy'] = (data['energy'] * 1000).to('keV')
     plot_data(data, sed=True, figure=fig)
     plt.close('all')
 


### PR DESCRIPTION
A test would fail because of an error in the test code that resulted in NaN values passed as axes limits.