### PR TITLE
Fix numpy deprecated API

### DIFF
--- a/naima/_astropy_init.py
+++ b/naima/_astropy_init.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__', '__githash__', 'test']
+__all__ = ['__version__', '__githash__']
 
 # this indicates whether or not we are in the package's setup.py
 try:
@@ -22,98 +22,20 @@ try:
 except ImportError:
     __githash__ = ''
 
-# set up the test command
-def _get_test_runner():
-    import os
-    from astropy.tests.helper import TestRunner
-    return TestRunner(os.path.dirname(__file__))
 
-def test(package=None, test_path=None, args=None, plugins=None,
-         verbose=False, pastebin=None, remote_data=False, pep8=False,
-         pdb=False, coverage=False, open_files=False, **kwargs):
-    """
-    Run the tests using `py.test <http://pytest.org/latest>`__. A proper set
-    of arguments is constructed and passed to `pytest.main`_.
-
-    .. _py.test: http://pytest.org/latest/
-    .. _pytest.main: http://pytest.org/latest/builtin.html#pytest.main
-
-    Parameters
-    ----------
-    package : str, optional
-        The name of a specific package to test, e.g. 'io.fits' or 'utils'.
-        If nothing is specified all default tests are run.
-
-    test_path : str, optional
-        Specify location to test by path. May be a single file or
-        directory. Must be specified absolutely or relative to the
-        calling directory.
-
-    args : str, optional
-        Additional arguments to be passed to pytest.main_ in the ``args``
-        keyword argument.
-
-    plugins : list, optional
-        Plugins to be passed to pytest.main_ in the ``plugins`` keyword
-        argument.
-
-    verbose : bool, optional
-        Convenience option to turn on verbose output from py.test_. Passing
-        True is the same as specifying ``'-v'`` in ``args``.
-
-    pastebin : {'failed','all',None}, optional
-        Convenience option for turning on py.test_ pastebin output. Set to
-        ``'failed'`` to upload info for failed tests, or ``'all'`` to upload
-        info for all tests.
-
-    remote_data : bool, optional
-        Controls whether to run tests marked with @remote_data. These
-        tests use online data and are not run by default. Set to True to
-        run these tests.
-
-    pep8 : bool, optional
-        Turn on PEP8 checking via the `pytest-pep8 plugin
-        <http://pypi.python.org/pypi/pytest-pep8>`_ and disable normal
-        tests. Same as specifying ``'--pep8 -k pep8'`` in ``args``.
-
-    pdb : bool, optional
-        Turn on PDB post-mortem analysis for failing tests. Same as
-        specifying ``'--pdb'`` in ``args``.
-
-    coverage : bool, optional
-        Generate a test coverage report.  The result will be placed in
-        the directory htmlcov.
-
-    open_files : bool, optional
-        Fail when any tests leave files open.  Off by default, because
-        this adds extra run time to the test suite.  Works only on
-        platforms with a working ``lsof`` command.
-
-    parallel : int, optional
-        When provided, run the tests in parallel on the specified
-        number of CPUs.  If parallel is negative, it will use the all
-        the cores on the machine.  Requires the
-        `pytest-xdist <https://pypi.python.org/pypi/pytest-xdist>`_ plugin
-        installed. Only available when using Astropy 0.3 or later.
-
-    kwargs
-        Any additional keywords passed into this function will be passed
-        on to the astropy test runner.  This allows use of test-related
-        functionality implemented in later versions of astropy without
-        explicitly updating the package template.
-
-    """
-    test_runner = _get_test_runner()
-    return test_runner.run_tests(
-        package=package, test_path=test_path, args=args,
-        plugins=plugins, verbose=verbose, pastebin=pastebin,
-        remote_data=remote_data, pep8=pep8, pdb=pdb,
-        coverage=coverage, open_files=open_files, **kwargs)
-
-if not _ASTROPY_SETUP_:
+if not _ASTROPY_SETUP_:  # noqa
     import os
     from warnings import warn
-    from astropy import config
+    from astropy.config.configuration import (
+        update_default_config,
+        ConfigurationDefaultMissingError,
+        ConfigurationDefaultMissingWarning)
+
+    # Create the test function for self test
+    from astropy.tests.runner import TestRunner
+    test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
+    test.__test__ = False
+    __all__ += ['test']
 
     # add these here so we only need to cleanup the namespace at the end
     config_dir = None
@@ -123,16 +45,16 @@ if not _ASTROPY_SETUP_:
         config_template = os.path.join(config_dir, __package__ + ".cfg")
         if os.path.isfile(config_template):
             try:
-                config.configuration.update_default_config(
+                update_default_config(
                     __package__, config_dir, version=__version__)
             except TypeError as orig_error:
                 try:
-                    config.configuration.update_default_config(
-                        __package__, config_dir)
-                except config.configuration.ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] + " Cannot install default profile. If you are "
+                    update_default_config(__package__, config_dir)
+                except ConfigurationDefaultMissingError as e:
+                    wmsg = (e.args[0] +
+                            " Cannot install default profile. If you are "
                             "importing from source, this is expected.")
-                    warn(config.configuration.ConfigurationDefaultMissingWarning(wmsg))
+                    warn(ConfigurationDefaultMissingWarning(wmsg))
                     del e
-                except:
+                except Exception:
                     raise orig_error

--- a/naima/core.py
+++ b/naima/core.py
@@ -110,7 +110,7 @@ def lnprob(pars, data, modelfunc, priorfunc):
 
             MODEL_IN_BLOB = False
             for blob in modelout[1:]:
-                if np.all(blob == model):
+                if np.array_equal(blob, model):
                     MODEL_IN_BLOB = True
 
             if MODEL_IN_BLOB:

--- a/naima/model_fitter.py
+++ b/naima/model_fitter.py
@@ -5,8 +5,6 @@ from __future__ import (absolute_import, division, print_function,
 import numpy as np
 import astropy.units as u
 from astropy.extern import six
-import matplotlib.pyplot as plt
-from matplotlib.widgets import Button, Slider, CheckButtons
 
 from .core import lnprobmodel, _prefit
 from .plot import color_cycle, _plot_data_to_ax
@@ -68,6 +66,9 @@ class InteractiveModelFitter(object):
                  labels=None,
                  sed=True,
                  auto_update=True):
+
+        import matplotlib.pyplot as plt
+        from matplotlib.widgets import Button, Slider, CheckButtons
 
         self.pars = p0
         self.P0_IS_ML = False
@@ -273,4 +274,5 @@ class InteractiveModelFitter(object):
         self.P0_IS_ML = P0_IS_ML
 
     def close_fig(self, event):
+        import matplotlib.pyplot as plt
         plt.close(self.fig)

--- a/naima/models.py
+++ b/naima/models.py
@@ -6,6 +6,7 @@ import os
 import numpy as np
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
+from astropy.table import Table
 from .extern.validator import (validate_scalar, validate_array,
                                validate_physical_type)
 from .radiative import Synchrotron, InverseCompton, PionDecay, Bremsstrahlung
@@ -19,8 +20,6 @@ __all__ = [
 
 
 def _validate_ene(ene):
-    from astropy.table import Table
-
     if isinstance(ene, dict) or isinstance(ene, Table):
         try:
             ene = validate_array(

--- a/naima/plot.py
+++ b/naima/plot.py
@@ -168,7 +168,7 @@ def _plot_chain_func(sampler, p, last_step=False):
         histtype='stepfilled',
         color=color_cycle[0],
         lw=0,
-        normed=1)
+        density=True)
     kde = stats.kde.gaussian_kde(dist)
     ax2.plot(x, kde(x), color='k', label='KDE')
     quant = [16, 50, 84]
@@ -1314,7 +1314,7 @@ def plot_distribution(samples, label, figure=None):
         histtype='stepfilled',
         color=color_cycle[0],
         lw=0,
-        normed=1)
+        density=True)
     if isinstance(samples, u.Quantity):
         samples_nounit = samples.value
     else:

--- a/naima/radiative.py
+++ b/naima/radiative.py
@@ -154,7 +154,7 @@ class BaseElectron(BaseRadiative):
         log10gmin = np.log10(self.Eemin / mec2).value
         log10gmax = np.log10(self.Eemax / mec2).value
         return np.logspace(log10gmin, log10gmax,
-                           self.nEed * (log10gmax - log10gmin))
+                           int(self.nEed * (log10gmax - log10gmin)))
 
     @property
     def _nelec(self):
@@ -189,10 +189,10 @@ class BaseElectron(BaseRadiative):
             if Eemin is None:
                 Eemin = self.Eemin
 
-            log10gmin = np.log10(Eemin / mec2)
-            log10gmax = np.log10(Eemax / mec2)
+            log10gmin = np.log10(Eemin / mec2).value
+            log10gmax = np.log10(Eemax / mec2).value
             gam = np.logspace(log10gmin, log10gmax,
-                              self.nEed * (log10gmax - log10gmin))
+                              int(self.nEed * (log10gmax - log10gmin)))
             nelec = self.particle_distribution(gam * mec2).to(1 /
                                                               mec2_unit).value
             We = trapz_loglog(gam * nelec, gam * mec2)
@@ -993,7 +993,8 @@ class BaseProton(BaseRadiative):
         return np.logspace(
             np.log10(self.Epmin.to('GeV').value),
             np.log10(self.Epmax.to('GeV').value),
-            self.nEpd * (np.log10(self.Epmax / self.Epmin)))
+            int(self.nEpd * (np.log10(self.Epmax / self.Epmin)))
+        )
 
     @property
     def _J(self):
@@ -1030,8 +1031,10 @@ class BaseProton(BaseRadiative):
 
             log10Epmin = np.log10(Epmin.to('GeV').value)
             log10Epmax = np.log10(Epmax.to('GeV').value)
-            Ep = np.logspace(log10Epmin, log10Epmax,
-                             self.nEpd * (log10Epmax - log10Epmin)) * u.GeV
+            Ep = np.logspace(
+                log10Epmin, log10Epmax,
+                int(self.nEpd * (log10Epmax - log10Epmin))
+            ) * u.GeV
             pdist = self.particle_distribution(Ep)
             Wp = trapz_loglog(Ep * pdist, Ep).to('erg')
 

--- a/naima/tests/fixtures.py
+++ b/naima/tests/fixtures.py
@@ -88,7 +88,7 @@ def lnprior(pars):
     return logprob
 
 # Run sampler
-@pytest.fixture
+@pytest.fixture(scope='module')
 def sampler():
     p0=np.array((np.log(1.8e-12),2.4,np.log10(15.0),))
     labels=['log(norm)','index','log10(cutoff)']
@@ -97,7 +97,7 @@ def sampler():
         prior=lnprior, nwalkers=10, nburn=2, nrun=2, threads=1)
     return sampler
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def simple_sampler():
     p0=np.array((np.log(1.8e-12),2.4,np.log10(15.0),))
     labels=['log(norm)','index','log10(cutoff)']

--- a/naima/tests/test_functionfit.py
+++ b/naima/tests/test_functionfit.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import warnings
+
 import numpy as np
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
@@ -144,9 +146,12 @@ def test_prefit():
 
 @pytest.mark.skipif('not HAS_EMCEE or not HAS_SCIPY or not HAS_MATPLOTLIB')
 def test_interactive():
-    sampler, pos = get_sampler(
-        data_table=data_table, p0=p0, labels=labels, model=cutoffexp,
-        prior=lnprior, nwalkers=10, nburn=5, threads=1, interactive=True)
+    with warnings.catch_warnings():
+        # Matplotlib warns a lot when unable to bring up the widget
+        warnings.simplefilter("ignore")
+        sampler, pos = get_sampler(
+            data_table=data_table, p0=p0, labels=labels, model=cutoffexp,
+            prior=lnprior, nwalkers=10, nburn=5, threads=1, interactive=True)
 
 
 @pytest.mark.skipif('not HAS_EMCEE')

--- a/naima/tests/test_interactive.py
+++ b/naima/tests/test_interactive.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
+import warnings
 
+import numpy as np
 import astropy.units as u
 from astropy.tests.helper import pytest
 from astropy.utils.data import get_pkg_data_filename
@@ -37,34 +38,40 @@ e_range = [100*u.GeV, 100*u.TeV]
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_modelwidget_inputs():
-    for dt in [data, None]:
-        for er in [e_range, None]:
-            for model in [modelfn, modelfn2]:
-                imf = InteractiveModelFitter(model, p0, labels=labels,
-                        data=dt, e_range=er)
-                imf.update('test')
-
-    for labs in [labels, labels[:2], None]:
-        imf = InteractiveModelFitter(model, p0, labels=labs)
-    for sed in [True, False]:
+    with warnings.catch_warnings():
+        # Matplotlib warns a lot when unable to bring up the widget
+        warnings.simplefilter("ignore")
         for dt in [data, None]:
-            imf = InteractiveModelFitter(model, p0, data=dt, labels=labels, sed=sed)
-    p0[1] = -2.7
-    imf = InteractiveModelFitter(model, p0, labels=labels)
-    labels[0] = 'norm'
-    imf = InteractiveModelFitter(model, p0, labels=labels)
-    plt.close('all')
+            for er in [e_range, None]:
+                for model in [modelfn, modelfn2]:
+                    imf = InteractiveModelFitter(model, p0, labels=labels,
+                            data=dt, e_range=er)
+                    imf.update('test')
+
+        for labs in [labels, labels[:2], None]:
+            imf = InteractiveModelFitter(model, p0, labels=labs)
+        for sed in [True, False]:
+            for dt in [data, None]:
+                imf = InteractiveModelFitter(model, p0, data=dt, labels=labels, sed=sed)
+        p0[1] = -2.7
+        imf = InteractiveModelFitter(model, p0, labels=labels)
+        labels[0] = 'norm'
+        imf = InteractiveModelFitter(model, p0, labels=labels)
+        plt.close('all')
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 def test_modelwidget_funcs():
-    imf = InteractiveModelFitter(modelfn, p0, data=data, labels=labels, auto_update=False)
-    assert imf.autoupdate is False
-    imf.update_autoupdate('test')
-    assert imf.autoupdate is True
-    imf.parsliders[0].val *= 2
-    imf.update_if_auto('test')
-    imf.close_fig('test')
+    with warnings.catch_warnings():
+        # Matplotlib warns a lot when unable to bring up the widget
+        warnings.simplefilter("ignore")
+        imf = InteractiveModelFitter(modelfn, p0, data=data, labels=labels, auto_update=False)
+        assert imf.autoupdate is False
+        imf.update_autoupdate('test')
+        assert imf.autoupdate is True
+        imf.parsliders[0].val *= 2
+        imf.update_if_auto('test')
+        imf.close_fig('test')
 
-    imf = InteractiveModelFitter(modelfn, p0, labels=labels, auto_update=False)
-    imf.update('test')
-    plt.close('all')
+        imf = InteractiveModelFitter(modelfn, p0, labels=labels, auto_update=False)
+        imf.update('test')
+        plt.close('all')

--- a/naima/tests/test_models.py
+++ b/naima/tests/test_models.py
@@ -75,8 +75,6 @@ def test_synchrotron_lum(particle_dists):
         assert lsy.unit == u.erg / u.s
         lsys.append(lsy.value)
 
-    print(lsys)
-    print(Wes)
     assert_allclose(lsys, lum_ref)
     assert_allclose(Wes, We_ref)
 

--- a/naima/tests/test_models.py
+++ b/naima/tests/test_models.py
@@ -4,8 +4,23 @@ import numpy as np
 from numpy.testing import assert_allclose
 from astropy.tests.helper import pytest
 from astropy.extern import six
+from astropy.modeling.blackbody import blackbody_nu
 
 from ..utils import trapz_loglog
+from ..models import (
+    Bremsstrahlung,
+    BrokenPowerLaw,
+    EblAbsorptionModel,
+    ExponentialCutoffBrokenPowerLaw,
+    ExponentialCutoffPowerLaw,
+    InverseCompton,
+    LogParabola,
+    PionDecay,
+    PowerLaw,
+    Synchrotron,
+    TableModel
+)
+from ..radiative import PionDecayKelner06
 
 try:
     import scipy
@@ -37,7 +52,6 @@ pdist_unit = 1 / u.Unit(m_e * c**2)
 
 @pytest.fixture
 def particle_dists():
-    from ..models import ExponentialCutoffPowerLaw, PowerLaw, BrokenPowerLaw
     ECPL = ExponentialCutoffPowerLaw(amplitude=1 * pdist_unit,
                                      e_0=e_0,
                                      alpha=alpha,
@@ -56,7 +70,6 @@ def test_synchrotron_lum(particle_dists):
     """
     test sync calculation
     """
-    from ..models import Synchrotron
 
     ECPL, PL, BPL = particle_dists
 
@@ -92,7 +105,6 @@ def test_bolometric_luminosity(particle_dists):
     """
     test sync calculation
     """
-    from ..models import Synchrotron
 
     ECPL, PL, BPL = particle_dists
 
@@ -108,7 +120,6 @@ def test_compute_We(particle_dists):
     """
     test sync calculation
     """
-    from ..models import Synchrotron, PionDecay
 
     ECPL, PL, BPL = particle_dists
 
@@ -135,7 +146,6 @@ def test_set_We(particle_dists):
     """
     test sync calculation
     """
-    from ..models import Synchrotron, PionDecay
 
     ECPL, PL, BPL = particle_dists
 
@@ -169,7 +179,6 @@ def test_bremsstrahlung_lum(particle_dists):
     """
     test sync calculation
     """
-    from ..models import Bremsstrahlung
 
     ECPL, PL, BPL = particle_dists
 
@@ -188,7 +197,6 @@ def test_inverse_compton_lum(particle_dists):
     """
     test IC calculation
     """
-    from ..models import InverseCompton
 
     ECPL, PL, BPL = particle_dists
 
@@ -217,7 +225,6 @@ def test_anisotropic_inverse_compton_lum(particle_dists):
     """
     test IC calculation
     """
-    from ..models import InverseCompton
 
     ECPL, PL, BPL = particle_dists
 
@@ -243,12 +250,10 @@ def test_monochromatic_inverse_compton(particle_dists):
     """
     test IC monochromatic against khangulyan et al.
     """
-    from ..models import InverseCompton, PowerLaw
 
     PL = PowerLaw(1 / u.eV, 1 * u.TeV, 3)
 
     # compute a blackbody spectrum with 1 eV/cm3 at 30K
-    from astropy.modeling.blackbody import blackbody_nu
     Ephbb = np.logspace(-3.5, -1.5, 100) * u.eV
     lambdabb = Ephbb.to('AA', equivalencies=u.equivalencies.spectral())
     T = 30 * u.K
@@ -282,7 +287,6 @@ def test_flux_sed(particle_dists):
     """
     test IC calculation
     """
-    from ..models import InverseCompton, Synchrotron, PionDecay
 
     ECPL, PL, BPL = particle_dists
 
@@ -320,7 +324,6 @@ def test_ic_seed_input(particle_dists):
     """
     test initialization of different input formats for seed photon fields
     """
-    from ..models import InverseCompton
 
     ECPL, PL, BPL = particle_dists
 
@@ -350,7 +353,6 @@ def test_ic_seed_fluxes(particle_dists):
     """
     test per seed flux computation
     """
-    from ..models import InverseCompton
 
     _, PL, _ = particle_dists
 
@@ -381,7 +383,6 @@ def test_pion_decay(particle_dists):
     """
     test ProtonOZM
     """
-    from ..models import PionDecay
 
     ECPL, PL, BPL = particle_dists
 
@@ -448,7 +449,6 @@ def test_pion_decay_kelner(particle_dists):
     """
     test PionDecayKelner06
     """
-    from ..radiative import PionDecayKelner06 as PionDecay
 
     ECPL, PL, BPL = particle_dists
 
@@ -458,8 +458,7 @@ def test_pion_decay_kelner(particle_dists):
     lum_ref = 5.54580582494601e-13 * u.erg / u.s
 
     energy = np.logspace(9, 13, 20) * u.eV
-    pp = PionDecay(ECPL, **proton_properties)
-    Wp = pp.Wp.to('erg').value
+    pp = PionDecayKelner06(ECPL, **proton_properties)
     lpp = trapz_loglog(pp.flux(energy, 0) * energy, energy).to('erg/s')
     assert (lpp.unit == u.erg / u.s)
 
@@ -469,8 +468,6 @@ def test_pion_decay_kelner(particle_dists):
 def test_inputs():
     """ test input validation with LogParabola and ExponentialCutoffBrokenPowerLaw
     """
-
-    from ..models import LogParabola, ExponentialCutoffBrokenPowerLaw
 
     LP = LogParabola(1., e_0, 1.7, 0.2)
     LP._memoize = True
@@ -492,7 +489,6 @@ def test_inputs():
 
 
 def test_tablemodel():
-    from ..models import TableModel
 
     lemin, lemax = -4, 2
     # test an exponential cutoff PL with index 2, cutoff at 10 TeV
@@ -528,7 +524,6 @@ def test_eblabsorptionmodel():
     """
     test EblAbsorptionModel
     """
-    from ..models import EblAbsorptionModel, BrokenPowerLaw
 
     lemin, lemax = -4, 2
 

--- a/naima/utils.py
+++ b/naima/utils.py
@@ -302,6 +302,9 @@ def trapz_loglog(y, x, axis=-1, intervals=False):
     slice1[axis] = slice(None, -1)
     slice2[axis] = slice(1, None)
 
+    slice1 = tuple(slice1)
+    slice2 = tuple(slice2)
+
     if x.ndim == 1:
         shape = [1] * y.ndim
         shape[axis] = x.shape[0]


### PR DESCRIPTION
Use `np.array_equal` instead of `all` and elementwise test in `naima.core`. Other deprecated APIs, such as the `normed` kwarg in matplotlib hist, have been removed.