### PR TITLE
Fix plot_blob bugs

### DIFF
--- a/naima/plot.py
+++ b/naima/plot.py
@@ -881,12 +881,10 @@ def plot_fit(
     if e_range is None and not hasattr(sampler, "blobs"):
         e_range = data["energy"][[0, -1]] * np.array((1.0 / 3.0, 3.0))
 
-    if (
-        plotdata is None
-        and len(model_ML[0]) == len(data["energy"])
-        and model_ML[0].unit.is_equivalent(data["flux"].unit)
-    ):
-        plotdata = True
+    if plotdata is None and len(model_ML[0]) == len(data["energy"]):
+        model_unit, _ = sed_conversion(model_ML[0], model_ML[1].unit, sed)
+        data_unit, _ = sed_conversion(data["energy"], data["flux"].unit, sed)
+        plotdata = model_unit.is_equivalent(data_unit)
     elif plotdata is None:
         plotdata = False
 

--- a/naima/plot.py
+++ b/naima/plot.py
@@ -1417,18 +1417,20 @@ def plot_distribution(samples, label, figure=None):
 
     histnbins = min(max(25, int(len(samples) / 100.0)), 100)
     xlabel = "" if label is None else label
+
+    if isinstance(samples, u.Quantity):
+        samples_nounit = samples.value
+    else:
+        samples_nounit = samples
+
     n, x, _ = ax.hist(
-        samples,
+        samples_nounit,
         histnbins,
         histtype="stepfilled",
         color=color_cycle[0],
         lw=0,
         density=True,
     )
-    if isinstance(samples, u.Quantity):
-        samples_nounit = samples.value
-    else:
-        samples_nounit = samples
 
     kde = stats.kde.gaussian_kde(samples_nounit)
     ax.plot(x, kde(x), color="k", label="KDE")

--- a/naima/plot.py
+++ b/naima/plot.py
@@ -881,7 +881,11 @@ def plot_fit(
     if e_range is None and not hasattr(sampler, "blobs"):
         e_range = data["energy"][[0, -1]] * np.array((1.0 / 3.0, 3.0))
 
-    if len(model_ML[0]) == len(data["energy"]) and plotdata is None:
+    if (
+        plotdata is None
+        and len(model_ML[0]) == len(data["energy"])
+        and model_ML[0].unit.is_equivalent(data["flux"].unit)
+    ):
         plotdata = True
     elif plotdata is None:
         plotdata = False

--- a/naima/plot.py
+++ b/naima/plot.py
@@ -1322,14 +1322,17 @@ def plot_data(
 
     try:
         data = validate_data_table(input_data)
-    except TypeError:
+    except TypeError as exc:
         if hasattr(input_data, "data"):
             data = input_data.data
         elif isinstance(input_data, dict) and "energy" in input_data.keys():
             data = input_data
         else:
-            log.warning("input_data format not know, no plotting data!")
-            return None
+            log.warning(
+                "input_data format unknown, no plotting data! "
+                "Data loading exception: {}".format(exc)
+            )
+            raise
 
     if figure is None:
         f = plt.figure()

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,7 @@ install_requires = (
         "matplotlib",
         "scipy",
         "h5py",
+        "pyyaml",
     ],
 )
 


### PR DESCRIPTION
This PR fixes:

- Passing samples without units to `mpl.hist` when blob is scalar so that the distribution is plotted correctly.
-  Not attempting to plot data on top of the blob model when the units of a blob and of the data flux are not compatible.

Fixes #172.