### PR TITLE
Remove astropy<4.0 constraint in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ package_info["package_data"][PACKAGENAME].extend(c_files)
 
 install_requires = (
     [
-        "astropy>=1.0.2,<4.0",
+        "astropy>=1.0.2",
         "emcee>=2.2.0",
         "corner",
         "matplotlib",


### PR DESCRIPTION
@zblz - I see you added a `astropy<4.0` constraint in `install_requires` in `setup.py` here:
https://github.com/zblz/naima/pull/186/files#diff-2eeaed663bd0d25b7e608891384b7298R99

From the `naima` maintainer perspective it's understandable, you can't be sure if something will break with Astropy 4.0.

But from the user perspective and for us in Gammapy from the "depends on both" perspective it's problematic. As soon as Astropy 4.0 is released and shipped with conda, `pip install naima` will fail or pick an oder version, because you forbid it here.

In practice, it's very rare for Python packages to put constraints in this direction, and I think it's very unlikely that Astropy 4.0 will break things for Naima (or Gammapy).

So: OK to remove this constraint again?