### PR TITLE
Fix quantity array comparison in lnprob

### DIFF
--- a/src/naima/core.py
+++ b/src/naima/core.py
@@ -106,8 +106,8 @@ def lnprob(pars, data, modelfunc, priorfunc):
     else:
         lnprob_priors = priorfunc(pars)
 
-    # If prior is -np.inf, avoid calling the function as invalid calls may be made,
-    # and the result will be discarded anyway
+    # If prior is -np.inf, avoid calling the function as invalid calls may be
+    # made, and the result will be discarded anyway
     if not np.isinf(lnprob_priors):
         modelout = modelfunc(pars, data)
 
@@ -120,8 +120,14 @@ def lnprob(pars, data, modelfunc, priorfunc):
 
             MODEL_IN_BLOB = False
             for blob in modelout[1:]:
-                if np.array_equal(blob, model):
-                    MODEL_IN_BLOB = True
+                try:
+                    if np.array_equal(blob, model):
+                        MODEL_IN_BLOB = True
+                except (TypeError, u.UnitConversionError):
+                    # np.array_equal will fail if there is no
+                    # __array_function__ implementation in one of the types, or
+                    # if they are of incompatible types
+                    pass
 
             if MODEL_IN_BLOB:
                 blob = modelout[1:]

--- a/src/naima/tests/test_models.py
+++ b/src/naima/tests/test_models.py
@@ -209,9 +209,9 @@ def test_inverse_compton_lum(particle_dists):
     ECPL, PL, BPL = particle_dists
 
     lum_ref = [
-        0.00027822017772343816,
-        0.004821189282097695,
-        0.00012916583207749083,
+        0.0002782201669858555,
+        0.004821189222961136,
+        0.00012916582897424096,
     ]
 
     lums = []
@@ -228,7 +228,7 @@ def test_inverse_compton_lum(particle_dists):
     ic.flux(data2)
 
     lic = trapz_loglog(ic.flux(energy, 0) * energy, energy).to("erg/s")
-    assert_allclose(lic.value, 0.0005833034007064158)
+    assert_allclose(lic.value, 0.0005833030059049264)
 
 
 @pytest.mark.skipif("not HAS_SCIPY")
@@ -241,7 +241,7 @@ def test_anisotropic_inverse_compton_lum(particle_dists):
 
     angles = [45, 90, 135] * u.deg
 
-    lum_ref = [48901.427779, 111356.569043, 149800.431109]
+    lum_ref = [48901.363932, 111356.423781, 149800.235776]
 
     lums = []
     for angle in angles:


### PR DESCRIPTION
The new `__array_function__` hooks for numpy functions in astropy quantities made `np.array_equal` throw exceptions in cases where before it would have returned false. This PR catches those exceptions and treats them as the quantities not being equal.