### PR TITLE
Sort concatenated data tables by energy

### DIFF
--- a/src/naima/utils.py
+++ b/src/naima/utils.py
@@ -105,6 +105,10 @@ def validate_data_table(data_table, sed=None):
         for row in dt:
             data_new.add_row(row)
 
+    # Sort by energy so model curves and interpolation work correctly
+    sort_idx = np.argsort(data_new["energy"])
+    data_new = data_new[sort_idx]
+
     return data_new
 
 


### PR DESCRIPTION
## Summary

- When multiple data tables are passed to `validate_data_table` in non-monotonic energy order (e.g. `[vhe_table, xray_table]`), the concatenated table had unsorted energies
- This caused model curves to zigzag in plots and broke `scipy.interpolate.interp1d` in residual computation
- Fitting was unaffected (per-point likelihoods are order-independent)
- Fix: sort the concatenated table by energy after merging. The `group` column preserves per-table identity for plot styling

## Test plan

- [x] Added `test_reversed_table_order` — verifies energies are sorted regardless of input order and that both orderings produce the same result
- [x] Full test suite passes (`tox -e py313 -- tests/`)

Closes #247